### PR TITLE
Fixes to FFT, KMP, and Suffix Array

### DIFF
--- a/KMP.cpp
+++ b/KMP.cpp
@@ -10,7 +10,8 @@ void buildTable(string& w, VI& t)
 {
   t = VI(w.length());  
   int i = 2, j = 0;
-  t[0] = -1; t[1] = 0;
+  t[0] = -1;
+  if (w.length() > 1) t[1] = 0;
   
   while(i < w.length())
   {

--- a/fft.cpp
+++ b/fft.cpp
@@ -1,11 +1,13 @@
+typedef long double T_DOUBLE; // May be changed to double for more speed and less precision
+
 struct cpx
 {
   cpx(){}
-  cpx(double aa):a(aa){}
-  cpx(double aa, double bb):a(aa),b(bb){}
-  double a;
-  double b;
-  double modsq(void) const
+  cpx(T_DOUBLE aa):a(aa),b(0){}
+  cpx(T_DOUBLE aa, T_DOUBLE bb):a(aa),b(bb){}
+  T_DOUBLE a;
+  T_DOUBLE b;
+  T_DOUBLE modsq(void) const
   {
     return a * a + b * b;
   }
@@ -31,12 +33,12 @@ cpx operator /(cpx a, cpx b)
   return cpx(r.a / b.modsq(), r.b / b.modsq());
 }
 
-cpx EXP(double theta)
+cpx EXP(T_DOUBLE theta)
 {
   return cpx(cos(theta),sin(theta));
 }
 
-const double two_pi = 4 * acos(0);
+const T_DOUBLE two_pi = 4 * acos((T_DOUBLE)0);
 
 // in:     input array
 // out:    output array
@@ -52,27 +54,31 @@ void FFT(cpx *in, cpx *out, int step, int size, int dir)
     out[0] = in[0];
     return;
   }
-  FFT(in, out, step * 2, size / 2, dir);
-  FFT(in + step, out + size / 2, step * 2, size / 2, dir);
-  for(int i = 0 ; i < size / 2 ; i++)
+  int half = size >> 1;
+  FFT(in, out, step * 2, half, dir);
+  FFT(in + step, out + half, step << 1, half, dir);
+  for(int i = 0 ; i < half ; i++)
   {
     cpx even = out[i];
-    cpx odd = out[i + size / 2];
+    cpx odd = out[i + half];
     out[i] = even + EXP(dir * two_pi * i / size) * odd;
-    out[i + size / 2] = even + EXP(dir * two_pi * (i + size / 2) / size) * odd;
+    out[i + half] = even + EXP(dir * two_pi * (i + half) / size) * odd;
   }
 }
 
-// Usage:
-// f[0...N-1] and g[0..N-1] are numbers
-// Want to compute the convolution h, defined by
-// h[n] = sum of f[k]g[n-k] (k = 0, ..., N-1).
-// Here, the index is cyclic; f[-1] = f[N-1], f[-2] = f[N-2], etc.
-// Let F[0...N-1] be FFT(f), and similarly, define G and H.
-// The convolution theorem says H[n] = F[n]G[n] (element-wise product).
-// To compute h[] in O(N log N) time, do the following:
-//   1. Compute F and G (pass dir = 1 as the argument).
-//   2. Get H by element-wise multiplying F and G.
-//   3. Get h by taking the inverse FFT (use dir = -1 as the argument)
-//      and *dividing by N*. DO NOT FORGET THIS SCALING FACTOR.
-// To compute an *acyclic* convolution, pad f and g to the right with zeroes.
+// f:      input array f
+// g:      input array g
+// h:      output array h
+// size:   length of f/g/h {MUST BE A POWER OF 2}
+// RESULT: h[i] = sum of f[k]*g[i-k] for k=0..(size-1)
+// Note: f and g are cyclic (e.g. f[-1] = f[size-1]), so they may be padded
+// the right with zeroes to instead compute an acyclic convolution.
+void FFTConvolution(cpx *f, cpx *g, cpx *h, int size)
+{
+  cpx *F = new cpx[size], *G = new cpx[size], *H = new cpx[size];
+  FFT(f, F, 1, size, 1);
+  FFT(g, G, 1, size, 1);
+  for (int i = 0; i < size; i++) H[i] = F[i] * G[i];
+  FFT(H, h, 1, size, -1);
+  for (int i = 0; i < size; i++) h[i] = h[i] / size;
+}

--- a/fft.cpp
+++ b/fft.cpp
@@ -81,4 +81,7 @@ void FFTConvolution(cpx *f, cpx *g, cpx *h, int size)
   for (int i = 0; i < size; i++) H[i] = F[i] * G[i];
   FFT(H, h, 1, size, -1);
   for (int i = 0; i < size; i++) h[i] = h[i] / size;
+  delete [] F;
+  delete [] G;
+  delete [] H;
 }

--- a/suffix-array.cpp
+++ b/suffix-array.cpp
@@ -15,7 +15,7 @@ struct SuffixArray {
   vector<pair<pair<int,int>,int> > M;
 
   SuffixArray(const string &s) : L(s.length()), s(s), P(1, vector<int>(L, 0)), M(L) {
-    for (int i = 0; i < L; i++) P[0][i] = int(s[i]);
+    for (int i = 0; i < L; i++) P[0][i] = L==1 ? i : int(s[i]);
     for (int skip = 1, level = 1; skip < L; skip *= 2, level++) {
       P.push_back(vector<int>(L, 0));
       for (int i = 0; i < L; i++) 


### PR DESCRIPTION
FFT: Fixed initialization issue and compiler error, made it easier to
set the underlying double type, and added a wrapper function for
convolutions

KMP: Added a special case to make it work for |w|=1

Suffix Array: Added a special case to make it work for L=1 (reported at https://github.com/t3nsor/codebook/issues/3)